### PR TITLE
fixed spec mailer deliveries clear issue

### DIFF
--- a/spec/controllers/forgot_passwords_controller_spec.rb
+++ b/spec/controllers/forgot_passwords_controller_spec.rb
@@ -31,6 +31,8 @@ describe ForgotPasswordsController do
 
       before(:each) { post :create, email: user.email }
 
+      after { ActionMailer::Base.deliveries.clear }
+
       it_behaves_like "tokenable" do
         let(:object) { user }
       end


### PR DESCRIPTION
fixing spec by clearing mailer deliveries after forgot password token was mailed.